### PR TITLE
Eslint rule merging logic

### DIFF
--- a/src/convertConfig.ts
+++ b/src/convertConfig.ts
@@ -3,6 +3,7 @@ import { ProcessLogger } from "./logger";
 import { reportConversionResults } from "./reportConversionResults";
 import { convertRules, ConfigConversionResults } from "./rules/convertRules";
 import { converters } from "./rules/converters";
+import { mergers } from "./rules/mergers";
 import { TSLintToESLintSettings, TSLintToESLintResult, ResultStatus } from "./types";
 
 export type CreateNewConfiguration = (conversionResults: ConfigConversionResults) => Promise<void>;
@@ -48,6 +49,7 @@ export const convertConfig = async ({
             ...value,
         })),
         converters,
+        mergers,
     );
 
     await createNewConfiguration(convertedRules);

--- a/src/creation/createNewConfiguration.test.ts
+++ b/src/creation/createNewConfiguration.test.ts
@@ -3,7 +3,7 @@ import { createNewConfiguration } from "./createNewConfiguration";
 import { ConfigConversionResults } from "../rules/convertRules";
 
 describe("createNewConfiguration", () => {
-    it("writes only formatted rules when there are no missing rules", async () => {
+    it("excludes the tslint plugin when there are no missing rules", async () => {
         // Arrange
         const conversionResults: ConfigConversionResults = {
             ...emptyConversionResults,
@@ -17,7 +17,17 @@ describe("createNewConfiguration", () => {
         // Assert
         expect(writeFile).toHaveBeenLastCalledWith(
             ".eslintrc.json",
-            JSON.stringify({ rules: {} }, undefined, 4),
+            JSON.stringify(
+                {
+                    parser: "@typescript-eslint/parser",
+                    parserOptions: {
+                        project: "tsconfig.json",
+                    },
+                    rules: {},
+                },
+                undefined,
+                4,
+            ),
         );
     });
 
@@ -44,11 +54,11 @@ describe("createNewConfiguration", () => {
             ".eslintrc.json",
             JSON.stringify(
                 {
-                    plugins: ["@typescript-eslint/tslint"],
                     parser: "@typescript-eslint/parser",
                     parserOptions: {
                         project: "tsconfig.json",
                     },
+                    plugins: ["@typescript-eslint/tslint"],
                     rules: {
                         "@typescript-eslint/tslint/config": [
                             "error",

--- a/src/creation/createNewConfiguration.ts
+++ b/src/creation/createNewConfiguration.ts
@@ -8,12 +8,12 @@ export const createNewConfiguration = async (
     writeFile: WriteFile,
 ) => {
     const output = {
+        parser: "@typescript-eslint/parser",
+        parserOptions: {
+            project: "tsconfig.json",
+        },
         ...(conversionResults.missing.length && {
             plugins: ["@typescript-eslint/tslint"],
-            parser: "@typescript-eslint/parser",
-            parserOptions: {
-                project: "tsconfig.json",
-            },
         }),
         rules: formatConvertedRules(conversionResults),
     };

--- a/src/rules/merger.ts
+++ b/src/rules/merger.ts
@@ -1,0 +1,7 @@
+/**
+ * Merges two ESLint rule result outputs to a single result.
+ */
+export type RuleMerger = (
+    existingOptions: any[] | undefined,
+    newOptions: any[] | undefined,
+) => any[];

--- a/src/rules/mergers.ts
+++ b/src/rules/mergers.ts
@@ -1,0 +1,7 @@
+import { mergeBanTypes } from "./mergers/ban-types";
+import { mergeNoUnnecessaryTypeAssertion } from "./mergers/no-unnecessary-type-assertion";
+
+export const mergers = new Map([
+    ["@typescript-eslint/ban-types", mergeBanTypes],
+    ["@typescript-eslint/no-unnecessary-type-assertion", mergeNoUnnecessaryTypeAssertion],
+]);

--- a/src/rules/mergers/ban-types.ts
+++ b/src/rules/mergers/ban-types.ts
@@ -1,0 +1,16 @@
+import { RuleMerger } from "../merger";
+
+export const mergeBanTypes: RuleMerger = (existingOptions, newOptions) => {
+    if (existingOptions === undefined && newOptions === undefined) {
+        return [];
+    }
+
+    return [
+        {
+            types: {
+                ...(existingOptions && existingOptions[0].types),
+                ...(newOptions && newOptions[0].types),
+            },
+        },
+    ];
+};

--- a/src/rules/mergers/no-unnecessary-type-assertion.ts
+++ b/src/rules/mergers/no-unnecessary-type-assertion.ts
@@ -1,0 +1,31 @@
+import { RuleMerger } from "../merger";
+
+export const mergeNoUnnecessaryTypeAssertion: RuleMerger = (existingOptions, newOptions) => {
+    if (existingOptions === undefined && newOptions === undefined) {
+        return [];
+    }
+
+    let typesToIgnore: string[] | undefined;
+
+    for (const options of [existingOptions, newOptions]) {
+        if (
+            options === undefined ||
+            options.length === 0 ||
+            options[0].typesToIgnore === undefined
+        ) {
+            continue;
+        }
+
+        if (typesToIgnore === undefined) {
+            typesToIgnore = [];
+        }
+
+        typesToIgnore.push(...options[0].typesToIgnore);
+    }
+
+    return [
+        {
+            ...(typesToIgnore !== undefined && { typesToIgnore }),
+        },
+    ];
+};

--- a/src/rules/mergers/tests/ban-types.test.ts
+++ b/src/rules/mergers/tests/ban-types.test.ts
@@ -1,0 +1,27 @@
+import { mergeBanTypes } from "../ban-types";
+
+describe(mergeBanTypes, () => {
+    test("neither types existing", () => {
+        const result = mergeBanTypes(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+
+    test("original type existing", () => {
+        const result = mergeBanTypes([{ types: { a: "original" } }], undefined);
+
+        expect(result).toEqual([{ types: { a: "original" } }]);
+    });
+
+    test("new type existing", () => {
+        const result = mergeBanTypes(undefined, [{ types: { b: "new" } }]);
+
+        expect(result).toEqual([{ types: { b: "new" } }]);
+    });
+
+    test("both types existing", () => {
+        const result = mergeBanTypes([{ types: { a: "original" } }], [{ types: { b: "new" } }]);
+
+        expect(result).toEqual([{ types: { a: "original", b: "new" } }]);
+    });
+});

--- a/src/rules/mergers/tests/no-unnecessary-type-assertion.test.ts
+++ b/src/rules/mergers/tests/no-unnecessary-type-assertion.test.ts
@@ -1,0 +1,60 @@
+import { mergeNoUnnecessaryTypeAssertion } from "../no-unnecessary-type-assertion";
+
+describe(mergeNoUnnecessaryTypeAssertion, () => {
+    test("neither options existing", () => {
+        const result = mergeNoUnnecessaryTypeAssertion(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+
+    test("neither typesToIgnore existing", () => {
+        const result = mergeNoUnnecessaryTypeAssertion([{}], [{}]);
+
+        expect(result).toEqual([{}]);
+    });
+
+    test("original typesToIgnore existing but empty", () => {
+        const result = mergeNoUnnecessaryTypeAssertion([{ typesToIgnore: [] }], undefined);
+
+        expect(result).toEqual([{ typesToIgnore: [] }]);
+    });
+
+    test("original typesToIgnore existing", () => {
+        const result = mergeNoUnnecessaryTypeAssertion(
+            [{ typesToIgnore: ["original"] }],
+            undefined,
+        );
+
+        expect(result).toEqual([{ typesToIgnore: ["original"] }]);
+    });
+
+    test("new typesToIgnore existing but empty", () => {
+        const result = mergeNoUnnecessaryTypeAssertion(undefined, [{ typesToIgnore: [] }]);
+
+        expect(result).toEqual([{ typesToIgnore: [] }]);
+    });
+
+    test("new typesToIgnore existing", () => {
+        const result = mergeNoUnnecessaryTypeAssertion(undefined, [{ typesToIgnore: ["new"] }]);
+
+        expect(result).toEqual([{ typesToIgnore: ["new"] }]);
+    });
+
+    test("both typesToIgnore existing but empty", () => {
+        const result = mergeNoUnnecessaryTypeAssertion(
+            [{ typesToIgnore: [] }],
+            [{ typesToIgnore: [] }],
+        );
+
+        expect(result).toEqual([{ typesToIgnore: [] }]);
+    });
+
+    test("both typesToIgnore existing", () => {
+        const result = mergeNoUnnecessaryTypeAssertion(
+            [{ typesToIgnore: ["original"] }],
+            [{ typesToIgnore: ["new"] }],
+        );
+
+        expect(result).toEqual([{ typesToIgnore: ["original", "new"] }]);
+    });
+});


### PR DESCRIPTION
Starts off with ban-types and no-unnecessary-type-assertion.

Fixes #8. 