### PR TITLE
Always output sourceType: module in parser options

### DIFF
--- a/src/creation/writeConversionResults.test.ts
+++ b/src/creation/writeConversionResults.test.ts
@@ -32,6 +32,7 @@ describe("writeConversionResults", () => {
                     parser: "@typescript-eslint/parser",
                     parserOptions: {
                         project: "tsconfig.json",
+                        sourceType: "module",
                     },
                     plugins: ["@typescript-eslint"],
                     rules: {},
@@ -72,6 +73,7 @@ describe("writeConversionResults", () => {
                     parser: "@typescript-eslint/parser",
                     parserOptions: {
                         project: "tsconfig.json",
+                        sourceType: "module",
                     },
                     plugins: ["@typescript-eslint", "@typescript-eslint/tslint"],
                     rules: {

--- a/src/creation/writeConversionResults.ts
+++ b/src/creation/writeConversionResults.ts
@@ -23,6 +23,7 @@ export const writeConversionResults = async (
         parser: "@typescript-eslint/parser",
         parserOptions: {
             project: "tsconfig.json",
+            sourceType: "module",
         },
         plugins,
         rules: formatConvertedRules(ruleConversionResults, originalConfigurations.tslint),


### PR DESCRIPTION
Fixes #47.