### PR TITLE
Replaced erroneous object-shorthand outputs of rule converters

### DIFF
--- a/src/rules/converters/one-variable-per-declaration.ts
+++ b/src/rules/converters/one-variable-per-declaration.ts
@@ -7,7 +7,7 @@ export const convertOneVariablePerDeclaration: RuleConverter = tslintRule => {
                 ...(!tslintRule.ruleArguments.includes("ignore-for-loop") && {
                     notices: ["Variables declared in for loops will no longer be checked."],
                 }),
-                ruleName: "object-shorthand",
+                ruleName: "one-var",
             },
         ],
     };

--- a/src/rules/converters/prefer-const.ts
+++ b/src/rules/converters/prefer-const.ts
@@ -7,7 +7,7 @@ export const convertPreferConst: RuleConverter = tslintRule => {
                 ...(tslintRule.ruleArguments.length !== 0 && {
                     ruleArguments: tslintRule.ruleArguments,
                 }),
-                ruleName: "object-shorthand",
+                ruleName: "prefer-const",
             },
         ],
     };

--- a/src/rules/converters/tests/one-variable-per-declaration.test.ts
+++ b/src/rules/converters/tests/one-variable-per-declaration.test.ts
@@ -10,7 +10,7 @@ describe(convertOneVariablePerDeclaration, () => {
             rules: [
                 {
                     notices: ["Variables declared in for loops will no longer be checked."],
-                    ruleName: "object-shorthand",
+                    ruleName: "one-var",
                 },
             ],
         });
@@ -24,7 +24,7 @@ describe(convertOneVariablePerDeclaration, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "object-shorthand",
+                    ruleName: "one-var",
                 },
             ],
         });

--- a/src/rules/converters/tests/prefer-const.test.ts
+++ b/src/rules/converters/tests/prefer-const.test.ts
@@ -9,7 +9,7 @@ describe(convertPreferConst, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "object-shorthand",
+                    ruleName: "prefer-const",
                 },
             ],
         });
@@ -24,7 +24,7 @@ describe(convertPreferConst, () => {
             rules: [
                 {
                     ruleArguments: ["all"],
-                    ruleName: "object-shorthand",
+                    ruleName: "prefer-const",
                 },
             ],
         });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #55 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

A couple of rule converters were giving out `object-shorthand` instead of their actual rule equivalents.