### PR TITLE
Replace fs promises api with utils.promisify

### DIFF
--- a/src/adapters/fsFileSystem.ts
+++ b/src/adapters/fsFileSystem.ts
@@ -4,6 +4,7 @@ import { promisify } from "util";
 import { FileSystem } from "./fileSystem";
 
 const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
 
 export const fsFileSystem: FileSystem = {
     fileExists: async (filePath: string) => {
@@ -22,7 +23,7 @@ export const fsFileSystem: FileSystem = {
     },
     writeFile: async (filePath: string, contents: string) => {
         try {
-            return fs.promises.writeFile(filePath, contents);
+            return writeFile(filePath, contents);
         } catch (error) {
             return error;
         }

--- a/src/adapters/fsFileSystem.ts
+++ b/src/adapters/fsFileSystem.ts
@@ -3,6 +3,8 @@ import { promisify } from "util";
 
 import { FileSystem } from "./fileSystem";
 
+const readFile = promisify(fs.readFile);
+
 export const fsFileSystem: FileSystem = {
     fileExists: async (filePath: string) => {
         try {
@@ -13,7 +15,6 @@ export const fsFileSystem: FileSystem = {
     },
     readFile: async (filePath: string) => {
         try {
-            const readFile = promisify(fs.readFile);
             return (await readFile(filePath)).toString();
         } catch (error) {
             return error;

--- a/src/adapters/fsFileSystem.ts
+++ b/src/adapters/fsFileSystem.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import { promisify } from "util";
 
 import { FileSystem } from "./fileSystem";
 
@@ -12,7 +13,8 @@ export const fsFileSystem: FileSystem = {
     },
     readFile: async (filePath: string) => {
         try {
-            return (await fs.promises.readFile(filePath)).toString();
+            const readFile = promisify(fs.readFile);
+            return (await readFile(filePath)).toString();
         } catch (error) {
             return error;
         }


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #63
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
This PR replaces the `fs.promises` API with `util.promisify` in order to support Node 8.x.

Edit: Not sure how to test this change.