### PR TITLE
Fixed .length errors in formatMissingRules

### DIFF
--- a/src/conversion/convertConfig.test.ts
+++ b/src/conversion/convertConfig.test.ts
@@ -14,7 +14,7 @@ const createStubDependencies = (
 const createStubOriginalConfigurationsData = () => ({
     tslint: {
         rules: [],
-        ruleDirectories: [],
+        rulesDirectory: [],
     },
 });
 

--- a/src/creation/formatConvertedRules.test.ts
+++ b/src/creation/formatConvertedRules.test.ts
@@ -2,7 +2,7 @@ import { createEmptyConversionResults } from "../conversion/conversionResults.st
 import { formatConvertedRules } from "./formatConvertedRules";
 
 const originalConfiguration = {
-    ruleDirectories: [],
+    rulesDirectory: [],
     rules: {},
 };
 

--- a/src/creation/formatConvertedRules.ts
+++ b/src/creation/formatConvertedRules.ts
@@ -19,7 +19,7 @@ export const formatConvertedRules = (
     if (conversionResults.missing.length !== 0) {
         output["@typescript-eslint/tslint/config"] = formatMissingRules(
             conversionResults.missing,
-            tslintConfiguration.ruleDirectories,
+            tslintConfiguration.rulesDirectory,
         );
     }
 

--- a/src/creation/formatMissingRules.test.ts
+++ b/src/creation/formatMissingRules.test.ts
@@ -111,7 +111,7 @@ describe("formatMissingRules", () => {
 
     it("includes rule directories when there are rule directories", () => {
         // Arrange
-        const ruleDirectories = ["./path/to/rules"];
+        const rulesDirectory = ["./path/to/rules"];
         const missing: TSLintRuleOptions[] = [
             {
                 ruleArguments: [],
@@ -121,13 +121,13 @@ describe("formatMissingRules", () => {
         ];
 
         // Act
-        const output = formatMissingRules(missing, ruleDirectories);
+        const output = formatMissingRules(missing, rulesDirectory);
 
         // Assert
         expect(output).toEqual([
             "error",
             {
-                ruleDirectories,
+                rulesDirectory,
                 rules: {
                     "tslint-rule-a": true,
                 },

--- a/src/creation/formatMissingRules.ts
+++ b/src/creation/formatMissingRules.ts
@@ -1,6 +1,6 @@
 import { TSLintRuleOptions } from "../rules/types";
 
-export const formatMissingRules = (missing: TSLintRuleOptions[], ruleDirectories: string[]) => {
+export const formatMissingRules = (missing: TSLintRuleOptions[], rulesDirectory: string[]) => {
     const rules: { [i: string]: unknown } = {};
 
     for (const rule of missing.sort((a, b) => a.ruleName.localeCompare(b.ruleName))) {
@@ -12,7 +12,7 @@ export const formatMissingRules = (missing: TSLintRuleOptions[], ruleDirectories
     return [
         "error",
         {
-            ...(ruleDirectories.length !== 0 && { ruleDirectories }),
+            ...(rulesDirectory.length !== 0 && { rulesDirectory }),
             rules,
         },
     ];

--- a/src/creation/writeConversionResults.test.ts
+++ b/src/creation/writeConversionResults.test.ts
@@ -3,7 +3,7 @@ import { writeConversionResults } from "./writeConversionResults";
 
 const originalConfigurations = {
     tslint: {
-        ruleDirectories: [],
+        rulesDirectory: [],
         rules: {},
     },
 };

--- a/src/input/findOriginalConfigurations.test.ts
+++ b/src/input/findOriginalConfigurations.test.ts
@@ -20,7 +20,7 @@ const createDependencies = (overrides: Partial<FindOriginalConfigurationsDepende
         devDependencies: {},
     }),
     findTSLintConfiguration: async () => ({
-        ruleDirectories: [],
+        rulesDirectory: [],
         rules: {},
     }),
     findTypeScriptConfiguration: async () => ({
@@ -64,7 +64,7 @@ describe("findOriginalConfigurations", () => {
         expect(result).toEqual({
             data: {
                 tslint: {
-                    ruleDirectories: [],
+                    rulesDirectory: [],
                     rules: {},
                 },
             },
@@ -91,7 +91,7 @@ describe("findOriginalConfigurations", () => {
                     devDependencies: {},
                 },
                 tslint: {
-                    ruleDirectories: [],
+                    rulesDirectory: [],
                     rules: {},
                 },
                 typescript: {

--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -2,7 +2,7 @@ import { Exec } from "../adapters/exec";
 import { findConfiguration } from "./findConfiguration";
 
 export type TSLintConfiguration = {
-    ruleDirectories: string[];
+    rulesDirectory: string[];
     rules: TSLintConfigurationRules;
 };
 
@@ -11,7 +11,7 @@ export type TSLintConfigurationRules = {
 };
 
 const defaultTSLintConfiguration = {
-    ruleDirectories: [],
+    rulesDirectory: [],
     rules: {},
 };
 

--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -53,7 +53,7 @@ describe("findTSLintConfiguration", () => {
 
         // Assert
         expect(result).toEqual({
-            ruleDirectories: [],
+            rulesDirectory: [],
             rules: {},
         });
     });

--- a/src/rules/convertRules.ts
+++ b/src/rules/convertRules.ts
@@ -5,6 +5,7 @@ import { convertRuleSeverity } from "./convertRuleSeverity";
 import { TSLintRuleOptions, ESLintRuleOptions } from "./types";
 import { RuleConverter } from "./converter";
 import { RuleMerger } from "./merger";
+import { formatRawTslintRule } from "./formatRawTslintRule";
 
 export type ConvertRulesDependencies = {
     converters: Map<string, RuleConverter>;
@@ -28,11 +29,9 @@ export const convertRules = (
     const packages = new Set<string>();
 
     for (const [ruleName, value] of Object.entries(rawTslintRules)) {
-        const tslintRule = {
-            ruleName,
-            ...value,
-        };
+        const tslintRule = formatRawTslintRule(ruleName, value);
         const conversion = convertRule(tslintRule, dependencies.converters);
+
         if (conversion === undefined) {
             if (tslintRule.ruleSeverity !== "off") {
                 missing.push(tslintRule);

--- a/src/rules/convertRules.ts
+++ b/src/rules/convertRules.ts
@@ -1,11 +1,11 @@
 import { TSLintConfigurationRules } from "../input/findTSLintConfiguration";
 import { ConversionError } from "./conversionError";
+import { RuleConverter } from "./converter";
 import { convertRule } from "./convertRule";
 import { convertRuleSeverity } from "./convertRuleSeverity";
-import { TSLintRuleOptions, ESLintRuleOptions } from "./types";
-import { RuleConverter } from "./converter";
-import { RuleMerger } from "./merger";
 import { formatRawTslintRule } from "./formatRawTslintRule";
+import { RuleMerger } from "./merger";
+import { TSLintRuleOptions, ESLintRuleOptions } from "./types";
 
 export type ConvertRulesDependencies = {
     converters: Map<string, RuleConverter>;

--- a/src/rules/formatRawTslintRule.test.ts
+++ b/src/rules/formatRawTslintRule.test.ts
@@ -1,0 +1,18 @@
+import { formatRawTslintRule } from "./formatRawTslintRule";
+
+describe("formatRawTslintRule", () => {
+    it("supplies default values when none are provided", () => {
+        // Arrange
+        const ruleName = "tslint-rule";
+
+        // Act
+        const formatted = formatRawTslintRule(ruleName, {});
+
+        // Assert
+        expect(formatted).toEqual({
+            ruleArguments: [],
+            ruleName,
+            ruleSeverity: "error",
+        });
+    });
+});

--- a/src/rules/formatRawTslintRule.ts
+++ b/src/rules/formatRawTslintRule.ts
@@ -1,0 +1,11 @@
+import { TSLintRuleOptions } from "./types";
+
+export const formatRawTslintRule = (
+    ruleName: string,
+    value: Partial<TSLintRuleOptions>,
+): TSLintRuleOptions => ({
+    ruleArguments: [],
+    ruleName,
+    ruleSeverity: "error",
+    ...value,
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #69. _Nice_.
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
Two problems:\n* It's `rulesDirectory`, not `ruleDirectories`...

`tslint.json` rule values that didn't provide `ruleArguments` weren't being given `[]` as defaults when being parsed. Added a unit test for this.
