### PR TITLE
Added 'publish' CircleCI step for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2.1
 
+references:
+    set_npm_token: &set_npm_token
+        run:
+            name: Add NPM auth token file
+            command: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+
 jobs:
     build:
         docker:
@@ -42,6 +48,22 @@ jobs:
                   at: "."
 
             - run: npm run eslint
+
+    publish:
+        docker:
+            - image: circleci/node:latest
+
+        working_directory: ~/repo
+
+        steps:
+            - checkout
+
+            - *set_npm_token
+
+            - attach_workspace:
+                  at: "."
+
+            - run: npm publish || exit 0
 
     prettier:
         docker:
@@ -93,6 +115,12 @@ workflows:
             - eslint:
                   requires:
                       - build
+            - publish:
+                  filters:
+                      branches:
+                          only: master
+                  requires:
+                      - tsc
             - prettier:
                   requires:
                       - build

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 *.log
 *.map
 coverage/
+src/**/*.stubs.ts
 src/**/*.test.ts
 src/**/*.ts
 !src/**/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,8 @@
 *.log
 *.map
 coverage/
-src/**/*.stubs.ts
-src/**/*.test.ts
+src/**/*.stubs.*
+src/**/*.test.*
 src/**/*.ts
 !src/**/*.d.ts
 src/**/*.test.d.ts


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #37
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Runs `npm publish` on each master build, ignoring any failure (such as from the version having not changed). Kind of like a try/catch with an empty catch block in CI. Heh.

Fixes 37.