### PR TITLE
Wrapped config lookup paths in quotes

### DIFF
--- a/src/input/findConfiguration.ts
+++ b/src/input/findConfiguration.ts
@@ -13,7 +13,7 @@ export const findConfiguration = async <Configuration>(
     command: string,
     config: string,
 ): Promise<DeepPartial<Configuration> | Error> => {
-    const fullCommand = `${command} ${config}`;
+    const fullCommand = `${command} "${config}"`;
     const stdout = await execAndCatch(exec, fullCommand);
 
     if (stdout instanceof Error) {

--- a/src/input/findESLintConfiguration.test.ts
+++ b/src/input/findESLintConfiguration.test.ts
@@ -33,7 +33,7 @@ describe("findESLintConfiguration", () => {
         await findESLintConfiguration(dependencies, createStubRawSettings());
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith("eslint --print-config ./eslintrc.js");
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`eslint --print-config "./eslintrc.js"`);
     });
 
     it("includes a configuration file in the ESLint command when one is provided", async () => {
@@ -48,7 +48,7 @@ describe("findESLintConfiguration", () => {
 
         // Assert
         expect(dependencies.exec).toHaveBeenLastCalledWith(
-            "eslint --print-config ./custom/eslintrc.js",
+            `eslint --print-config "./custom/eslintrc.js"`,
         );
     });
 

--- a/src/input/findPackagesConfiguration.test.ts
+++ b/src/input/findPackagesConfiguration.test.ts
@@ -10,7 +10,7 @@ describe("findPackagesConfiguration", () => {
         await findPackagesConfiguration(dependencies, undefined);
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith("cat ./package.json");
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`cat "./package.json"`);
     });
 
     it("includes a configuration file in the packages command when one is provided", async () => {
@@ -22,7 +22,7 @@ describe("findPackagesConfiguration", () => {
         await findPackagesConfiguration(dependencies, config);
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith("cat ./custom/package.json");
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`cat "./custom/package.json"`);
     });
 
     it("applies packages defaults when none are provided", async () => {

--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -26,7 +26,7 @@ describe("findTSLintConfiguration", () => {
         await findTSLintConfiguration(dependencies, undefined);
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith("tslint --print-config ./tslint.json");
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`tslint --print-config "./tslint.json"`);
     });
 
     it("includes a configuration file in the TSLint command when one is provided", async () => {
@@ -39,7 +39,7 @@ describe("findTSLintConfiguration", () => {
 
         // Assert
         expect(dependencies.exec).toHaveBeenLastCalledWith(
-            "tslint --print-config ./custom/tslint.json",
+            `tslint --print-config "./custom/tslint.json"`,
         );
     });
 

--- a/src/input/findTypeScriptConfiguration.test.ts
+++ b/src/input/findTypeScriptConfiguration.test.ts
@@ -26,7 +26,7 @@ describe("findTypeScriptConfiguration", () => {
         await findTypeScriptConfiguration(dependencies, undefined);
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith("cat ./tsconfig.json");
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`cat "./tsconfig.json"`);
     });
 
     it("includes a configuration file in the TypeScript command when one is provided", async () => {
@@ -38,7 +38,7 @@ describe("findTypeScriptConfiguration", () => {
         await findTypeScriptConfiguration(dependencies, config);
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith("cat ./custom/tsconfig.json");
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`cat "./custom/tsconfig.json"`);
     });
 
     it("applies TypeScript defaults when none are provided", async () => {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #80
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Wraps the `${config}` as `"${config}"` in `findConfiguration.ts` so the resultant command will be something like `cat ./path with spaces/tsconfig.json`.