### PR TITLE
Used tsc --showConfig instead of cat for --typescript configs

### DIFF
--- a/src/input/findTypeScriptConfiguration.test.ts
+++ b/src/input/findTypeScriptConfiguration.test.ts
@@ -26,7 +26,7 @@ describe("findTypeScriptConfiguration", () => {
         await findTypeScriptConfiguration(dependencies, undefined);
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith(`cat "./tsconfig.json"`);
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`tsc --showConfig -p "./tsconfig.json"`);
     });
 
     it("includes a configuration file in the TypeScript command when one is provided", async () => {
@@ -38,7 +38,9 @@ describe("findTypeScriptConfiguration", () => {
         await findTypeScriptConfiguration(dependencies, config);
 
         // Assert
-        expect(dependencies.exec).toHaveBeenLastCalledWith(`cat "./custom/tsconfig.json"`);
+        expect(dependencies.exec).toHaveBeenLastCalledWith(
+            `tsc --showConfig -p "./custom/tsconfig.json"`,
+        );
     });
 
     it("applies TypeScript defaults when none are provided", async () => {

--- a/src/input/findTypeScriptConfiguration.ts
+++ b/src/input/findTypeScriptConfiguration.ts
@@ -19,7 +19,7 @@ export const findTypeScriptConfiguration = async (
 ): Promise<TypeScriptConfiguration | Error> => {
     const rawConfiguration = await findConfiguration<TypeScriptConfiguration>(
         dependencies.exec,
-        "cat",
+        "tsc --showConfig -p",
         config || "./tsconfig.json",
     );
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #85
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Per #85, TypeScript has a native `--showConfig` flag we can use as of version 3.2. This PR uses that instead of `cat` to print TypeScript configuration files.