### PR TITLE
Persisted tsc task output to CircleCI workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,11 @@ jobs:
 
             - run: npm run tsc
 
+            - persist_to_workspace:
+                  root: "."
+                  paths:
+                      - src
+
 workflows:
     version: 2
     commit:


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #94 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

The `tsc` task isn't saving its output. Sigh.