### PR TITLE
Added an explicit error message for TSLint versions too low

### DIFF
--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -29,10 +29,16 @@ export const findTSLintConfiguration = async (
         config || "./tslint.json",
     );
 
-    return rawConfiguration instanceof Error
-        ? rawConfiguration
-        : {
-              ...defaultTSLintConfiguration,
-              ...rawConfiguration,
-          };
+    if (rawConfiguration instanceof Error) {
+        if (rawConfiguration.message.includes("unknown option `--print-config")) {
+            return new Error("TSLint v5.18 required. Please update your version.");
+        }
+
+        return rawConfiguration;
+    }
+
+    return {
+        ...defaultTSLintConfiguration,
+        ...rawConfiguration,
+    };
 };

--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -18,6 +18,22 @@ describe("findTSLintConfiguration", () => {
         );
     });
 
+    it("replaces an error with a v5.18 request when the --print-config option is unsupported", async () => {
+        // Arrange
+        const stderr = "unknown option `--print-config";
+        const dependencies = { exec: createStubThrowingExec({ stderr }) };
+
+        // Act
+        const result = await findTSLintConfiguration(dependencies, undefined);
+
+        // Assert
+        expect(result).toEqual(
+            expect.objectContaining({
+                message: "TSLint v5.18 required. Please update your version.",
+            }),
+        );
+    });
+
     it("defaults the configuration file when one isn't provided", async () => {
         // Arrange
         const dependencies = { exec: createStubExec() };


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #120
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

If the TSLint error message contains a complaint that `--print-config` is outdated, this gives a better error message.